### PR TITLE
Generate missing migrations

### DIFF
--- a/httpproxy/migrations/0002_auto_20160121_1940.py
+++ b/httpproxy/migrations/0002_auto_20160121_1940.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('httpproxy', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='requestparameter',
+            name='name',
+            field=models.CharField(max_length=100, verbose_name='name'),
+        ),
+        migrations.AlterField(
+            model_name='response',
+            name='content',
+            field=models.TextField(verbose_name='content'),
+        ),
+        migrations.AlterField(
+            model_name='response',
+            name='content_type',
+            field=models.CharField(max_length=200, verbose_name='content type'),
+        ),
+    ]


### PR DESCRIPTION
@yvandermeer cc @arpheno

Fix https://github.com/yvandermeer/django-http-proxy/issues/19

There are three alterations happening in the migrations here. I will address each one separately:
1. Change the `verbose_name` on `RequestParameter.name` from [`naam`](https://github.com/yvandermeer/django-http-proxy/blob/691e9ba6de0a3e377e3f568aaf0a8e0c6ed6388c/httpproxy/migrations/0001_initial.py#L37) to `name`.
2. Change the `verbose_name` on `Response.content` from [`inhoud`](https://github.com/yvandermeer/django-http-proxy/blob/691e9ba6de0a3e377e3f568aaf0a8e0c6ed6388c/httpproxy/migrations/0001_initial.py#L54) to `content`.
3. Change the `verbose_name` on `Response.content_type` from [`inhoudstype`](https://github.com/yvandermeer/django-http-proxy/blob/691e9ba6de0a3e377e3f568aaf0a8e0c6ed6388c/httpproxy/migrations/0001_initial.py#L53) to `content type`.

Without these alterations, one will see the following warning when trying to run migrations if `httpproxy` is in their `INSTALLED_APPS`.

```
Running migrations:
    No migrations to apply.
    Your models have changes that are not yet reflected in a migration, and so won't be applied.
    Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.
```

This PR resolves that issue by adding the required migrations here to `httpproxy`.
