### PR TITLE
allow full proxying

### DIFF
--- a/httpproxy/migrations/0001_initial.py
+++ b/httpproxy/migrations/0001_initial.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                 ('order', models.PositiveSmallIntegerField(default=1)),
                 ('name', models.CharField(max_length=100, verbose_name='naam')),
                 ('value', models.CharField(max_length=250, null=True, verbose_name='value', blank=True)),
-                ('request', models.ForeignKey(related_name='parameters', verbose_name='request', to='httpproxy.Request')),
+                ('request', models.ForeignKey(related_name='parameters', verbose_name='request', to='httpproxy.Request', on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ('order',),
@@ -52,7 +52,7 @@ class Migration(migrations.Migration):
                 ('status', models.PositiveSmallIntegerField(default=200)),
                 ('content_type', models.CharField(max_length=200, verbose_name='inhoudstype')),
                 ('content', models.TextField(verbose_name='inhoud')),
-                ('request', models.OneToOneField(verbose_name='request', to='httpproxy.Request')),
+                ('request', models.OneToOneField(verbose_name='request', to='httpproxy.Request', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'response',

--- a/httpproxy/models.py
+++ b/httpproxy/models.py
@@ -89,7 +89,7 @@ class Response(models.Model):
     The response that was recorded in response to the corresponding
     :class:`~httpproxy.models.Request`.
     """
-    request = models.OneToOneField(Request, verbose_name=_('request'))
+    request = models.OneToOneField(Request, verbose_name=_('request'), on_delete=models.CASCADE)
     status = models.PositiveSmallIntegerField(default=200)
     content_type = models.CharField(_('content type'), max_length=200)
     content = models.TextField(_('content'))

--- a/httpproxy/models.py
+++ b/httpproxy/models.py
@@ -68,7 +68,7 @@ class RequestParameter(models.Model):
         ('G', 'GET'),
         ('P', 'POST'),
     )
-    request = models.ForeignKey(Request, verbose_name=_('request'), related_name='parameters')
+    request = models.ForeignKey(Request, verbose_name=_('request'), related_name='parameters', on_delete=models.CASCADE)
     type = models.CharField(max_length=1, choices=REQUEST_TYPES, default='G')
     order = models.PositiveSmallIntegerField(default=1)
     name = models.CharField(_('name'), max_length=100)

--- a/httpproxy/views.py
+++ b/httpproxy/views.py
@@ -94,7 +94,7 @@ class HttpProxy(View):
         This way, any further processing of the proxy'd request can just ignore
         the url given to the proxy and use request.path safely instead.
         """
-        if not self.url.startswith('/'):
+        if self.base_url and not self.url.startswith('/'):
             self.url = '/' + self.url
         request.path = self.url
         request.path_info = self.url


### PR DESCRIPTION
Sometimes it would be useful to proxy the entire url but
the following directive throws exception
url(r'^proxy/(?P<url>.*)', HttpProxy.as_view(base_url="")),
because normalize_request puts a slash at the start of the url
I use django-http-proxy to combine images in html canvas from different sources bypassing CORS headers checking.
