### PR TITLE
Use a binary regex for binary data.

### DIFF
--- a/httpproxy/views.py
+++ b/httpproxy/views.py
@@ -12,7 +12,7 @@ from httpproxy.recorder import ProxyRecorder
 logger = logging.getLogger(__name__)
 
 
-REWRITE_REGEX = re.compile(r'((?:src|action|href)=["\'])/(?!\/)')
+REWRITE_REGEX = re.compile(br'((?:src|action|href)=["\'])/(?!\/)')
 
 class HttpProxy(View):
     """


### PR DESCRIPTION
@yvandermeer In python 3, `bytes` regexes can only match binary data, and `str` regexes can only match `str`. Since the `REWRITE_REGEX` is applied to binary data from the response, proxy views with `rewrite=True` fail on Python 3. This leads to failures like `TypeError: cannot use a string pattern on a bytes-like object`.

This PR updates the REWRITE_REGEX to be a binary regex. This is a no-op on python 2.

Thanks for your work writing this library!